### PR TITLE
Fix deserialization for TIME values

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/event/deserialization/EventDeserializer.java
@@ -217,6 +217,7 @@ public class EventDeserializer {
             deserializer.setDeserializeIntegerAsByteArray(
                 compatibilitySet.contains(CompatibilityMode.INTEGER_AS_BYTE_ARRAY)
             );
+            deserializer.setDeserializeWithNewTimeV2(compatibilitySet.contains(CompatibilityMode.USE_NEW_TIME_DESERIALIZER));
         }
     }
 
@@ -396,7 +397,11 @@ public class EventDeserializer {
         /**
          * Return TINY/SHORT/INT24/LONG/LONGLONG values as byte[]|s (instead of int|s).
          */
-        INTEGER_AS_BYTE_ARRAY
+        INTEGER_AS_BYTE_ARRAY,
+        /**
+         * Use new time deserializer; fix for negative TIME values
+         */
+        USE_NEW_TIME_DESERIALIZER
     }
 
     /**


### PR DESCRIPTION
The deserialization method for the TIME datatype was broken for negative TIME values. This change incorporates a fix that is based on another binlog client connector written in Go that has the correct deserialization implementation - https://github.com/go-mysql-org/go-mysql/blob/master/replication/row_event.go#L1696-L1755 (I more or less ported the Go code into Java).

The new deserializer can be used with `EventDeserializer.CompatibilityMode.USE_NEW_TIME_DESERIALIZER`. This mode can be set in our Engineering repo when initializing the binlog client.