### PR TITLE
feature(mysql-binlog): Add support for mysql_clear_password

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
@@ -169,7 +169,7 @@ public class Authenticator {
             this.scramble = buffer.readZeroTerminatedString();
             Command authCommand = new AuthenticateSHA2Command(scramble, password);
             channel.write(authCommand);
-        } else if (MYSQL_CLEAR_PASSWORD.equals(greetingPacket.getPluginProvidedData())) {
+        } else if (MYSQL_CLEAR_PASSWORD.equals(authName)) {
             authMethod = AuthMethod.CLEAR_PASSWORD;
 
             Command swithCommand = new AuthenticateClearPasswordCommand(password);

--- a/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
@@ -5,13 +5,7 @@ import com.github.shyiko.mysql.binlog.io.ByteArrayOutputStream;
 import com.github.shyiko.mysql.binlog.network.protocol.ErrorPacket;
 import com.github.shyiko.mysql.binlog.network.protocol.GreetingPacket;
 import com.github.shyiko.mysql.binlog.network.protocol.PacketChannel;
-import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateNativePasswordCommand;
-import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateSHA2Command;
-import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateSHA2RSAPasswordCommand;
-import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateSecurityPasswordCommand;
-import com.github.shyiko.mysql.binlog.network.protocol.command.ByteArrayCommand;
-import com.github.shyiko.mysql.binlog.network.protocol.command.Command;
-import com.github.shyiko.mysql.binlog.network.protocol.command.SSLRequestCommand;
+import com.github.shyiko.mysql.binlog.network.protocol.command.*;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -21,7 +15,8 @@ import java.util.logging.Logger;
 public class Authenticator {
     private enum AuthMethod {
         NATIVE,
-        CACHING_SHA2
+        CACHING_SHA2,
+        CLEAR_PASSWORD
     };
 
     private final GreetingPacket greetingPacket;
@@ -35,6 +30,7 @@ public class Authenticator {
 
     private final String SHA2_PASSWORD = "caching_sha2_password";
     private final String MYSQL_NATIVE = "mysql_native_password";
+    private final String MYSQL_CLEAR_PASSWORD = "mysql_clear_password";
 
     private AuthMethod authMethod = AuthMethod.NATIVE;
 
@@ -61,6 +57,9 @@ public class Authenticator {
         if ( SHA2_PASSWORD.equals(greetingPacket.getPluginProvidedData()) ) {
             authMethod = AuthMethod.CACHING_SHA2;
             authenticateCommand = new AuthenticateSHA2Command(schema, username, password, scramble, collation);
+        } else if (MYSQL_CLEAR_PASSWORD.equals(greetingPacket.getPluginProvidedData())) {
+            authMethod = AuthMethod.CLEAR_PASSWORD;
+            authenticateCommand = new AuthenticateClearPasswordCommand(password);
         } else {
             authMethod = AuthMethod.NATIVE;
             authenticateCommand = new AuthenticateSecurityPasswordCommand(schema, username, password, scramble, collation);

--- a/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
@@ -5,7 +5,13 @@ import com.github.shyiko.mysql.binlog.io.ByteArrayOutputStream;
 import com.github.shyiko.mysql.binlog.network.protocol.ErrorPacket;
 import com.github.shyiko.mysql.binlog.network.protocol.GreetingPacket;
 import com.github.shyiko.mysql.binlog.network.protocol.PacketChannel;
-import com.github.shyiko.mysql.binlog.network.protocol.command.*;
+import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateClearPasswordCommand;
+import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateNativePasswordCommand;
+import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateSHA2Command;
+import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateSHA2RSAPasswordCommand;
+import com.github.shyiko.mysql.binlog.network.protocol.command.AuthenticateSecurityPasswordCommand;
+import com.github.shyiko.mysql.binlog.network.protocol.command.ByteArrayCommand;
+import com.github.shyiko.mysql.binlog.network.protocol.command.Command;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/Authenticator.java
@@ -169,6 +169,11 @@ public class Authenticator {
             this.scramble = buffer.readZeroTerminatedString();
             Command authCommand = new AuthenticateSHA2Command(scramble, password);
             channel.write(authCommand);
+        } else if (MYSQL_CLEAR_PASSWORD.equals(greetingPacket.getPluginProvidedData())) {
+            authMethod = AuthMethod.CLEAR_PASSWORD;
+
+            Command swithCommand = new AuthenticateClearPasswordCommand(password);
+            channel.write(swithCommand);
         } else {
             throw new AuthenticationException("unsupported authentication method: " + authName);
         }

--- a/src/main/java/com/github/shyiko/mysql/binlog/network/protocol/command/AuthenticateClearPasswordCommand.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/protocol/command/AuthenticateClearPasswordCommand.java
@@ -1,0 +1,20 @@
+package com.github.shyiko.mysql.binlog.network.protocol.command;
+
+import com.github.shyiko.mysql.binlog.io.ByteArrayOutputStream;
+
+import java.io.IOException;
+
+public class AuthenticateClearPasswordCommand implements  Command {
+    private String password;
+
+    public AuthenticateClearPasswordCommand(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public byte[] toByteArray() throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        buffer.writeZeroTerminatedString(password);
+        return buffer.toByteArray();
+    }
+}

--- a/src/main/java/com/github/shyiko/mysql/binlog/network/protocol/command/AuthenticateClearPasswordCommand.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/network/protocol/command/AuthenticateClearPasswordCommand.java
@@ -5,7 +5,7 @@ import com.github.shyiko.mysql.binlog.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 public class AuthenticateClearPasswordCommand implements  Command {
-    private String password;
+    private final String password;
 
     public AuthenticateClearPasswordCommand(String password) {
         this.password = password;
@@ -13,8 +13,9 @@ public class AuthenticateClearPasswordCommand implements  Command {
 
     @Override
     public byte[] toByteArray() throws IOException {
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        buffer.writeZeroTerminatedString(password);
-        return buffer.toByteArray();
+        try(ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            buffer.writeZeroTerminatedString(password);
+            return buffer.toByteArray();
+        }
     }
 }


### PR DESCRIPTION
Closes [T-901563](https://fivetran.height.app/T-901563) Add mysql_clear_password to binlog client

### Description of Change

#### What does the change do?

The binlog client does not support [mysql_clear_password authentication](https://dev.mysql.com/doc/refman/8.4/en/cleartext-pluggable-authentication.html) which is a requirement for IAM auth.
When we configure the user to use IAM auth and try to connect to the DB as that user with a valid IAM auth token, during the handshake, the server requests that the token (password) be sent over as clear text. The default native auth mechanism scrambles the password before sending it over. During handshake, the client throws the exception `com.github.shyiko.mysql.binlog.network.AuthenticationException: unsupported authentication method: mysql_clear_password` and fails authentication.

This PR enables support for sending clear text tokens to the server. The Debezium fork recently added this support as well: https://github.com/debezium/mysql-binlog-connector-java/pull/11/files.

#### Steps to revert/rollback changes

Rollback this PR, rollback the PR in the engineering repo that switches our binlog client to use this tagged version.

### Functional Testing

**Have you run all the automated tests with and without the feature flag? (unit, integration and e2e)**

`<Post answer here instead of this line>`

**Did you perform any additional testing?**

This was tested manually against the IAM Auth POC code branch https://github.com/fivetran/engineering/pull/210423

### Performance Testing

**Does this change impact our performance? (Throughput/latency/sync times)**

This change should not impact performance.

**If this PR impacts performance, post JMH tests/staging benchmark results before and after change.**

`<Post answer here instead of this line>`

### Monitoring

**How to monitor the rollout of this PR? Post link to logs or dashboards where this change can be monitored.**

This change should _not_ affect any existing connectors or new connectors that do not use IAM auth. Since IAM auth is unreleased as of the creation of this PR, this should be a no-op at the moment. Lookout for any severe or warning logs related to authentication. Ideally we should not see any new behaviour at all.

### MAR Changes

**Will this change affect MAR in any way? How?**

`<Post answer here instead of this line>`

### Documentation/Changelog

**Does this change need to be documented anywhere?**

`<Post answer here instead of this line>`

<details>
  <summary>Some tips and links to help validate your PR...</summary>
  
  * Verify connector changes [using Sandbox Testing](https://docs.google.com/presentation/d/1uWnlFEaqV3fz_mUp6RcLDAQ4WS4UsPgzVc4qgzVVVfk/edit)
  * Verify website/dashboard changes using [App Testing](https://fivetran.slab.com/posts/how-to-run-debug-app-testing-fuvsac1o) or [App Demo](https://fivetran.slab.com/posts/how-to-use-demo-environment-to-test-dashboard-changes-wgucoipi)
  * Verify [changelog changes](https://docs.google.com/presentation/d/1V1Kk3ddPz6sRTA--gJ3dB5PgUGtQMw2goJ7Fkp-qssc/edit#slide=id.g2603d3e7dda_0_1365) locally with pnpm
  * Ensure proper tests requested [using branch postfix](https://fivetran.slab.com/posts/circle-ci-run-extra-jobs-by-condition-at-commit-workflow-pull-request-idzy33dl)
  
</details>

<!--Add a branch param on the badge below will scope the Build Badge to a particular branch (e.g. https://badge.buildkite.com/f0d2b608abc5fa9de2ba961fb23eb23ff651548571595149c4.svg?branch=main)-->

[![Build status](https://badge.buildkite.com/ff3e33cb259dac0e2547b487885d9107605b7b3ecbf2bb2469.svg?branch=main)](https://buildkite.com/fivetran/engineering-tests)